### PR TITLE
Do not close parameters dialog on download

### DIFF
--- a/src/components/ParametersDialog.vue
+++ b/src/components/ParametersDialog.vue
@@ -138,7 +138,6 @@ export default {
         type: "text/plain;charset=utf-8",
       });
       fileSaver.saveAs(yamlBlob, "parameters.yml");
-      this.show = false;
     },
     async sync() {
       function sleepMs(duration) {
@@ -191,6 +190,7 @@ export default {
         this.bluetoothSynchingState = false;
         this.bluetoothSynchingValue = 0;
         this.showSnackbar("Configuration synchronization succeeded", "success");
+        this.show = false;
       } catch (error) {
         console.log(error);
         this.bluetoothSynchingState = false;


### PR DESCRIPTION
- Parameters dialog will be closed for sync and push operations
- Parameters dialog won't be closed for download operation

Fixes #5 

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>