### PR TITLE
Remove 'tunnels' parameter creation on new device

### DIFF
--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -41,8 +41,7 @@ const actions = {
         db.collection("users").doc(context.state.id).collection("devices").doc(deviceId).set({
             creation_date: strftime("%Y-%m-%dT%H:%M:%S"),
             last_connection: 0,
-            parameters: {},
-            tunnels: {}
+            parameters: {}
         });
     }),
     deleteDevice: firestoreAction((context, deviceId) => {


### PR DESCRIPTION
The iombian-tunnels-handler service will take care of creating the 'tunnels' parameter, so devices without this service won't have the option to create tunnels.

Signed-off-by: Aitor Iturrioz <aiturrioz@tknika.eus>