### PR TITLE
Show manually installed services cards

### DIFF
--- a/src/assets/default_service_info.js
+++ b/src/assets/default_service_info.js
@@ -1,0 +1,12 @@
+const service_info = {
+    compose: {}, labels: {
+        author: "Unknown",
+        changelog: "No changelog available",
+        description: "No description available (manually installed service or version not available in the marketplace)",
+        id: "id",
+        name: "id",
+        version: "version",
+    }
+}
+
+export default service_info;

--- a/src/components/InstalledServiceCard.vue
+++ b/src/components/InstalledServiceCard.vue
@@ -66,7 +66,7 @@ Requires a service object with the properties of the labels of the firestore ser
       </v-card-text>
 
       <div class="d-flex justify-end gap-2 pe-4 py-4">
-        <v-btn color="secondary" plain @click="showDialog = true">
+        <v-btn v-if="isServiceEditable" color="secondary" plain @click="showDialog = true">
           Edit
           <v-icon right>mdi-pencil</v-icon>
         </v-btn>
@@ -110,7 +110,7 @@ Requires a service object with the properties of the labels of the firestore ser
           </v-dialog>
         </v-tooltip>
         <v-spacer />
-        <v-btn color="secondary" plain @click="showDialog = true">
+        <v-btn v-if="isServiceEditable" color="secondary" plain @click="showDialog = true">
           Edit
           <v-icon right>mdi-pencil</v-icon>
         </v-btn>
@@ -178,7 +178,8 @@ export default {
   },
   created() {
     this.envs = this.getEnvs(this.service);
-    if ("order" in Object.values(this.envs)[0]) {
+    const envs_values = Object.values(this.envs);
+    if (envs_values.length && "order" in envs_values[0]) {
       this.envs = this.sortEnvs(this.envs);
     }
 
@@ -207,6 +208,11 @@ export default {
     initialUpdatableValues() {
       return this.getUpdatableDefaultEnvs();
     },
+    /** Check if the service is editable. */
+    isServiceEditable() {
+      // A service is editable if it has any env var.
+      return Object.values(this.envs).length > 0;
+    }
   },
   methods: {
     /**

--- a/src/views/Device.vue
+++ b/src/views/Device.vue
@@ -66,6 +66,7 @@ To sync it manually, the configuration can be also downloaded.
 <script>
 import { apiKey, projectId } from "../main";
 import default_parameters from "../assets/default_parameters";
+import default_service_info from "../assets/default_service_info";
 import SystemCard from "../components/SystemCard.vue";
 import UserCard from "../components/UserCard.vue";
 import NetworkCard from "../components/NetworkCard.vue";
@@ -107,10 +108,19 @@ export default {
   computed: {
     /** Installed services of the device. */
     installedServices() {
-      return this.$store.state.deviceServices.services.map(({ id, version }) => (
-        this.$store.state.marketplaceServices.services.find(
-          (service) => (service.labels.version == version && service.labels.id == id))
-      )).map(({ labels }) => labels)
+      return this.$store.state.deviceServices.services.map(({ id, version }) => {
+        let service = this.$store.state.marketplaceServices.services.find(
+          (service) => (service.labels.version == version && service.labels.id == id));
+
+        if (service === undefined) {
+          default_service_info.labels.id = id;
+          default_service_info.labels.name = id;
+          default_service_info.labels.version = version;
+          return default_service_info;
+        }
+
+        return service
+    }).map(({ labels }) => labels)
     },
     /** The rest of the services that are not installed. */
     notInstalledServices() {

--- a/src/views/Device.vue
+++ b/src/views/Device.vue
@@ -110,16 +110,17 @@ export default {
     installedServices() {
       return this.$store.state.deviceServices.services.map(({ id, version }) => {
         let service = this.$store.state.marketplaceServices.services.find(
-          (service) => (service.labels.version == version && service.labels.id == id));
+          (service) => (service.labels?.version == version && service.labels?.id == id));
 
-        if (service === undefined) {
-          default_service_info.labels.id = id;
-          default_service_info.labels.name = id;
-          default_service_info.labels.version = version;
-          return default_service_info;
-        }
+          if (service === undefined) {
+            let service_info = JSON.parse(JSON.stringify(default_service_info));
+            service_info.labels.id = id;
+            service_info.labels.name = id;
+            service_info.labels.version = version;
+            return service_info;
+          }
 
-        return service
+          return service
     }).map(({ labels }) => labels)
     },
     /** The rest of the services that are not installed. */


### PR DESCRIPTION
This PR shows the services that have been manually added to a device but are not available in the marketplace. There can be different reasons for this:

- The user is testing a new service that has not been approved or uploaded to the marketplace
- The user is testing a new service version that it is not official yet

The shown information is minimal: id, name and version; so no description, author, documentation url... is provided.

Without this changes, no installed service card is shown, as the code fails to get the marketplace info